### PR TITLE
Port to 26.2 + Vulkan API Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
 plugins {
 	id 'dev.kikugie.stonecutter'
 	id 'maven-publish'
+	id 'idea'
 }
 
 apply plugin: project.minecraft_version.startsWith("1.") ? 'fabric-loom' : 'net.fabricmc.fabric-loom'
@@ -60,6 +61,7 @@ sourceSets {
 				exclude "restudio/reglass/client/screen/world/**"
 				exclude "restudio/reglass/client/screen/widget/world/**"
 				exclude "restudio/reglass/client/gui/LiquidGlassGuiElementRenderer.java"
+				exclude "restudio/reglass/mixin/accessor/GuiRendererAccessor.java"
 				exclude "restudio/reglass/mixin/accessor/TextIconButtonWidgetAccessor.java"
 				exclude "restudio/reglass/mixin/client/GuiRendererMixin.java"
 				exclude "restudio/reglass/mixin/client/MinecraftClientMixin.java"
@@ -174,6 +176,13 @@ def preprocessReglassSources = tasks.register('preprocessReglassSources') {
 		resourcesOutput.deleteDir()
 		preprocessReglassTree(rootProject.file('src/main/java'), javaOutput, project.minecraft_version)
 		preprocessReglassTree(rootProject.file('src/main/resources'), resourcesOutput, project.minecraft_version)
+	}
+}
+
+idea {
+	module {
+		sourceDirs += rootProject.file('src/main/java')
+		resourceDirs += rootProject.file('src/main/resources')
 	}
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,6 @@ rootProject.name = 'ReGlass'
 
 stonecutter {
 	create(getRootProject()) {
-		versions '26.1', '1.21.11'
+		versions '26.2', '26.1', '1.21.11'
 	}
 }

--- a/src/main/java/restudio/reglass/client/LiquidGlassPipelines.java
+++ b/src/main/java/restudio/reglass/client/LiquidGlassPipelines.java
@@ -1,7 +1,11 @@
 package restudio.reglass.client;
 
 import com.mojang.blaze3d.pipeline.RenderPipeline;
-//#if MC >= 26
+//#if MC >= 26.2
+import com.mojang.blaze3d.PrimitiveTopology;
+import com.mojang.blaze3d.pipeline.BindGroupLayout;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+//#elseif MC >= 26
 import com.mojang.blaze3d.pipeline.DepthStencilState;
 import com.mojang.blaze3d.platform.CompareOp;
 //#else
@@ -36,6 +40,29 @@ public final class LiquidGlassPipelines {
                     .withVertexShader(Identifier.of("reglass", "core/blit_fullscreen"))
                     .withFragmentShader(Identifier.of("reglass", "program/liquid_glass_gui"))
 //#endif
+//#if MC >= 26.2
+                    //Vulkan requires pipeline layouts to match actual shader bindings
+                    //unused entries can break pipeline creation
+                    .withBindGroupLayout(
+                            BindGroupLayout.builder()
+                                    .withUniform("SamplerInfo", UniformType.UNIFORM_BUFFER)
+                                    .withUniform("CustomUniforms", UniformType.UNIFORM_BUFFER)
+                                    .withUniform("WidgetInfo", UniformType.UNIFORM_BUFFER)
+                                    .withUniform("BgConfig", UniformType.UNIFORM_BUFFER)
+                                    .withSampler("Sampler0")
+                                    .withSampler("Sampler1")
+                                    .withSampler("Sampler2")
+                                    .withSampler("Sampler3")
+                                    .withSampler("Sampler4")
+                                    .withSampler("Sampler5")
+                                    .build()
+                    )
+                    .withVertexBinding(0, DefaultVertexFormat.POSITION)
+                    .withPrimitiveTopology(PrimitiveTopology.QUADS)
+                    //Minecraft leaves the no-depth Vulkan pipeline variant invalid, which can crash when bound.
+                    //the blend attachment still has to match the color target format
+                    .withColorTargetState(ColorTargetState.DEFAULT);
+//#else
                     .withUniform("Projection", UniformType.UNIFORM_BUFFER)
                     .withUniform("SamplerInfo", UniformType.UNIFORM_BUFFER)
                     .withUniform("CustomUniforms", UniformType.UNIFORM_BUFFER)
@@ -55,9 +82,14 @@ public final class LiquidGlassPipelines {
                     .withDepthWrite(false)
                     .withVertexFormat(VertexFormats.POSITION, VertexFormat.DrawMode.QUADS);
 //#endif
+//#endif
 
             LIQUID_GLASS_GUI = b.build();
+//#if MC >= 26.2
+            RenderSystem.getDevice().precompilePipeline(LIQUID_GLASS_GUI);
+//#else
             RenderSystem.getDevice().precompilePipeline(LIQUID_GLASS_GUI, null);
+//#endif
         }
         return LIQUID_GLASS_GUI;
     }

--- a/src/main/java/restudio/reglass/client/LiquidGlassPrecomputeRuntime.java
+++ b/src/main/java/restudio/reglass/client/LiquidGlassPrecomputeRuntime.java
@@ -98,9 +98,6 @@ public final class LiquidGlassPrecomputeRuntime {
                     .withVertexShader(VS_ID)
                     .withFragmentShader(BLUR_ID)
 //#if MC >= 26.2
-                    // No "Projection": blit_fullscreen.vsh emits clip-space directly and
-                    // neither blur shader uses it. The Vulkan backend rejects a layout
-                    // entry no shader binds (-> null pipeline crash).
                     .withBindGroupLayout(
                             BindGroupLayout.builder()
                                     .withUniform("SamplerInfo", UniformType.UNIFORM_BUFFER)
@@ -110,8 +107,6 @@ public final class LiquidGlassPrecomputeRuntime {
                     )
                     .withVertexBinding(0, DefaultVertexFormat.POSITION)
                     .withPrimitiveTopology(PrimitiveTopology.QUADS)
-                    // No depth-stencil state on this depth-less pass (null pipeline crash
-                    // on Vulkan otherwise); declare the colour target to match.
                     .withColorTargetState(ColorTargetState.DEFAULT)
 //#else
                     .withUniform("Projection", UniformType.UNIFORM_BUFFER)

--- a/src/main/java/restudio/reglass/client/LiquidGlassPrecomputeRuntime.java
+++ b/src/main/java/restudio/reglass/client/LiquidGlassPrecomputeRuntime.java
@@ -2,13 +2,17 @@ package restudio.reglass.client;
 
 import com.mojang.blaze3d.buffers.GpuBuffer;
 import com.mojang.blaze3d.buffers.Std140Builder;
-//#if MC >= 26
+//#if MC >= 26.2
+import com.mojang.blaze3d.GpuFormat;
+import com.mojang.blaze3d.PrimitiveTopology;
+import com.mojang.blaze3d.pipeline.BindGroupLayout;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
+//#elseif MC >= 26
 import com.mojang.blaze3d.pipeline.DepthStencilState;
+import com.mojang.blaze3d.platform.CompareOp;
 //#endif
 import com.mojang.blaze3d.pipeline.RenderPipeline;
-//#if MC >= 26
-import com.mojang.blaze3d.platform.CompareOp;
-//#else
+//#if MC < 26
 import com.mojang.blaze3d.platform.DepthTestFunction;
 //#endif
 import com.mojang.blaze3d.systems.RenderPass;
@@ -16,12 +20,18 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.FilterMode;
 import com.mojang.blaze3d.textures.GpuTexture;
 import com.mojang.blaze3d.textures.GpuTextureView;
+//#if MC < 26.2
 import com.mojang.blaze3d.textures.TextureFormat;
+//#endif
 import com.mojang.blaze3d.vertex.VertexFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+//#if MC >= 26.2
+import java.util.Optional;
+//#else
 import java.util.OptionalInt;
+//#endif
 //#if MC >= 26
 import net.minecraft.client.Minecraft;
 import com.mojang.blaze3d.shaders.UniformType;
@@ -87,6 +97,23 @@ public final class LiquidGlassPrecomputeRuntime {
 //#endif
                     .withVertexShader(VS_ID)
                     .withFragmentShader(BLUR_ID)
+//#if MC >= 26.2
+                    // No "Projection": blit_fullscreen.vsh emits clip-space directly and
+                    // neither blur shader uses it. The Vulkan backend rejects a layout
+                    // entry no shader binds (-> null pipeline crash).
+                    .withBindGroupLayout(
+                            BindGroupLayout.builder()
+                                    .withUniform("SamplerInfo", UniformType.UNIFORM_BUFFER)
+                                    .withUniform("Config", UniformType.UNIFORM_BUFFER)
+                                    .withSampler("DiffuseSampler")
+                                    .build()
+                    )
+                    .withVertexBinding(0, DefaultVertexFormat.POSITION)
+                    .withPrimitiveTopology(PrimitiveTopology.QUADS)
+                    // No depth-stencil state on this depth-less pass (null pipeline crash
+                    // on Vulkan otherwise); declare the colour target to match.
+                    .withColorTargetState(ColorTargetState.DEFAULT)
+//#else
                     .withUniform("Projection", UniformType.UNIFORM_BUFFER)
                     .withUniform("SamplerInfo", UniformType.UNIFORM_BUFFER)
                     .withUniform("Config", UniformType.UNIFORM_BUFFER)
@@ -99,8 +126,13 @@ public final class LiquidGlassPrecomputeRuntime {
                     .withDepthWrite(false)
                     .withVertexFormat(VertexFormats.POSITION, VertexFormat.DrawMode.QUADS)
 //#endif
+//#endif
                     .build();
+//#if MC >= 26.2
+            RenderSystem.getDevice().precompilePipeline(blurPipeline);
+//#else
             RenderSystem.getDevice().precompilePipeline(blurPipeline, null);
+//#endif
         }
 
         if (samplerInfoUbo == null) {
@@ -122,12 +154,12 @@ public final class LiquidGlassPrecomputeRuntime {
                 if (blurTempView != null) blurTempView.close();
                 blurTempTex.close();
             }
-            blurTempTex = RenderSystem.getDevice().createTexture("reglass blurTemp", 12, TextureFormat.RGBA8, w, h, 1, 1);
-//#if MC >= 26
-             blurTempView = RenderSystem.getDevice().createTextureView(blurTempTex);
+//#if MC >= 26.2
+            blurTempTex = RenderSystem.getDevice().createTexture("reglass blurTemp", 12, GpuFormat.RGBA8_UNORM, w, h, 1, 1);
 //#else
-            blurTempView = RenderSystem.getDevice().createTextureView(blurTempTex);
+            blurTempTex = RenderSystem.getDevice().createTexture("reglass blurTemp", 12, TextureFormat.RGBA8, w, h, 1, 1);
 //#endif
+            blurTempView = RenderSystem.getDevice().createTextureView(blurTempTex);
         }
     }
 
@@ -139,7 +171,11 @@ public final class LiquidGlassPrecomputeRuntime {
                 if (old != null) old.close();
                 tex.close();
             }
+//#if MC >= 26.2
+            GpuTexture newTex = RenderSystem.getDevice().createTexture("reglass blurred r=" + radius, 12, GpuFormat.RGBA8_UNORM, w, h, 1, 1);
+//#else
             GpuTexture newTex = RenderSystem.getDevice().createTexture("reglass blurred r=" + radius, 12, TextureFormat.RGBA8, w, h, 1, 1);
+//#endif
             GpuTextureView newView = RenderSystem.getDevice().createTextureView(newTex);
             blurredByRadius.put(radius, newTex);
             blurredViewByRadius.put(radius, newView);
@@ -164,7 +200,11 @@ public final class LiquidGlassPrecomputeRuntime {
     private void uploadBlur(GpuBuffer ubo, float dx, float dy, int radius) {
         radius = Math.max(0, Math.min(radius, MAX_RADIUS));
         float[] weights = gaussian(radius);
+//#if MC >= 26.2
+        try (var map = ubo.map(false, true)) {
+//#else
         try (var map = RenderSystem.getDevice().createCommandEncoder().mapBuffer(ubo, false, true)) {
+//#endif
             Std140Builder b = Std140Builder.intoBuffer(map.data());
             b.putVec4(dx, dy, (float) radius, 0f);
             for (int i = 0; i <= MAX_RADIUS; i++) {
@@ -182,7 +222,12 @@ public final class LiquidGlassPrecomputeRuntime {
     public void run() {
         ensurePipelines();
 
-//#if MC >= 26
+//#if MC >= 26.2
+        var mc = Minecraft.getInstance();
+        var main = mc.gameRenderer.mainRenderTarget();
+        int w = main.width;
+        int h = main.height;
+//#elseif MC >= 26
         var mc = Minecraft.getInstance();
         var main = mc.getMainRenderTarget();
         int w = main.width;
@@ -196,7 +241,11 @@ public final class LiquidGlassPrecomputeRuntime {
 
         ensureTempTarget(w, h);
 
+//#if MC >= 26.2
+        try (var map = samplerInfoUbo.map(false, true)) {
+//#else
         try (var map = RenderSystem.getDevice().createCommandEncoder().mapBuffer(samplerInfoUbo, false, true)) {
+//#endif
             Std140Builder.intoBuffer(map.data()).putVec2((float) w, (float) h).putVec2((float) w, (float) h);
         }
 
@@ -204,7 +253,11 @@ public final class LiquidGlassPrecomputeRuntime {
         GameRenderer gameRenderer = mc.gameRenderer;
         GuiRenderer guiRenderer = ((GameRendererAccessor) gameRenderer).getGuiRenderer();
         var quadVB = ((QuadVertexBufferProvider) guiRenderer).getQuadVertexBuffer();
-//#if MC >= 26
+//#if MC >= 26.2
+        var idxInfo = RenderSystem.getSequentialBuffer(PrimitiveTopology.QUADS);
+        var ib = idxInfo.getBuffer(6);
+        var it = idxInfo.type();
+//#elseif MC >= 26
         var idxInfo = RenderSystem.getSequentialBuffer(VertexFormat.Mode.QUADS);
         var ib = idxInfo.getBuffer(6);
         var it = idxInfo.type();
@@ -240,9 +293,15 @@ public final class LiquidGlassPrecomputeRuntime {
             uploadBlur(blurConfigUboX, 1f, 0f, radius);
             uploadBlur(blurConfigUboY, 0f, 1f, radius);
 
+//#if MC >= 26.2
+            try (RenderPass pass = ce.createRenderPass(() -> "reglass blur X r=" + radius, blurTempView, Optional.empty())) {
+//#else
             try (RenderPass pass = ce.createRenderPass(() -> "reglass blur X r=" + radius, blurTempView, OptionalInt.empty())) {
+//#endif
                 pass.setPipeline(blurPipeline);
+//#if MC < 26.2
                 RenderSystem.bindDefaultUniforms(pass);
+//#endif
                 pass.setUniform("SamplerInfo", samplerInfoUbo);
                 pass.setUniform("Config", blurConfigUboX);
 //#if MC >= 26
@@ -250,14 +309,26 @@ public final class LiquidGlassPrecomputeRuntime {
 //#else
                 pass.bindTexture("DiffuseSampler", main.getColorAttachmentView(), RenderSystem.getSamplerCache().get(FilterMode.LINEAR));
 //#endif
+//#if MC >= 26.2
+                pass.setVertexBuffer(0, quadVB.slice());
+                pass.setIndexBuffer(ib, it);
+                pass.drawIndexed(6, 1, 0, 0, 0);
+//#else
                 pass.setVertexBuffer(0, quadVB);
                 pass.setIndexBuffer(ib, it);
                 pass.drawIndexed(0, 0, 6, 1);
+//#endif
             }
 
+//#if MC >= 26.2
+            try (RenderPass pass = ce.createRenderPass(() -> "reglass blur Y r=" + radius, blurredViewByRadius.get(radius), Optional.empty())) {
+//#else
             try (RenderPass pass = ce.createRenderPass(() -> "reglass blur Y r=" + radius, blurredViewByRadius.get(radius), OptionalInt.empty())) {
+//#endif
                 pass.setPipeline(blurPipeline);
+//#if MC < 26.2
                 RenderSystem.bindDefaultUniforms(pass);
+//#endif
                 pass.setUniform("SamplerInfo", samplerInfoUbo);
                 pass.setUniform("Config", blurConfigUboY);
 //#if MC >= 26
@@ -265,9 +336,15 @@ public final class LiquidGlassPrecomputeRuntime {
 //#else
                 pass.bindTexture("DiffuseSampler", blurTempView, RenderSystem.getSamplerCache().get(FilterMode.LINEAR));
 //#endif
+//#if MC >= 26.2
+                pass.setVertexBuffer(0, quadVB.slice());
+                pass.setIndexBuffer(ib, it);
+                pass.drawIndexed(6, 1, 0, 0, 0);
+//#else
                 pass.setVertexBuffer(0, quadVB);
                 pass.setIndexBuffer(ib, it);
                 pass.drawIndexed(0, 0, 6, 1);
+//#endif
             }
         }
     }

--- a/src/main/java/restudio/reglass/client/LiquidGlassUniforms.java
+++ b/src/main/java/restudio/reglass/client/LiquidGlassUniforms.java
@@ -116,15 +116,24 @@ public final class LiquidGlassUniforms {
     public void uploadSharedUniforms() {
 //#if MC >= 26
         Minecraft mc = Minecraft.getInstance();
+//#if MC >= 26.2
+        int outW = mc.gameRenderer.mainRenderTarget().width;
+        int outH = mc.gameRenderer.mainRenderTarget().height;
+//#else
         int outW = mc.getMainRenderTarget().width;
         int outH = mc.getMainRenderTarget().height;
+//#endif
 //#else
         MinecraftClient mc = MinecraftClient.getInstance();
         int outW = mc.getFramebuffer().textureWidth;
         int outH = mc.getFramebuffer().textureHeight;
 //#endif
 
+//#if MC >= 26.2
+        try (var map = samplerInfo.map(false, true)) {
+//#else
         try (var map = RenderSystem.getDevice().createCommandEncoder().mapBuffer(samplerInfo, false, true)) {
+//#endif
             Std140Builder b = Std140Builder.intoBuffer(map.data());
             b.putVec2((float) outW, (float) outH);
             b.putVec2((float) outW, (float) outH);
@@ -135,7 +144,11 @@ public final class LiquidGlassUniforms {
 //#if MC >= 26
         GLFW.glfwGetCursorPos(mc.getWindow().handle(), mx, my);
         float scale = (float) mc.getWindow().getGuiScale();
+//#if MC >= 26.2
+        int fbH = mc.gameRenderer.mainRenderTarget().height;
+//#else
         int fbH = mc.getMainRenderTarget().height;
+//#endif
 //#else
         GLFW.glfwGetCursorPos(mc.getWindow().getHandle(), mx, my);
         float scale = (float) mc.getWindow().getScaleFactor();
@@ -145,7 +158,11 @@ public final class LiquidGlassUniforms {
         float time = (float) GLFW.glfwGetTime();
         ReGlassConfig config = ReGlassConfig.INSTANCE;
 
+//#if MC >= 26.2
+        try (var map = customUniforms.map(false, true)) {
+//#else
         try (var map = RenderSystem.getDevice().createCommandEncoder().mapBuffer(customUniforms, false, true)) {
+//#endif
             Std140Builder b = Std140Builder.intoBuffer(map.data());
             b.putFloat(time);
             b.align(16);
@@ -174,7 +191,11 @@ public final class LiquidGlassUniforms {
             b.putFloat(ReGlassAnim.INSTANCE.focusBorderSpeed());
         }
 
+//#if MC >= 26.2
+        try (var map = bgConfig.map(false, true)) {
+//#else
         try (var map = RenderSystem.getDevice().createCommandEncoder().mapBuffer(bgConfig, false, true)) {
+//#endif
             Std140Builder b = Std140Builder.intoBuffer(map.data());
             b.putFloat(ReGlassAnim.INSTANCE.shadowExpand());
             b.putFloat(ReGlassAnim.INSTANCE.shadowFactor());
@@ -226,7 +247,11 @@ public final class LiquidGlassUniforms {
     public void uploadWidgetInfo() {
 //#if MC >= 26
         Minecraft mc = Minecraft.getInstance();
+//#if MC >= 26.2
+        int fbH = mc.gameRenderer.mainRenderTarget().height;
+//#else
         int fbH = mc.getMainRenderTarget().height;
+//#endif
         float scale = (float) mc.getWindow().getGuiScale();
         List<LiquidGlassGuiElementRenderState> renderWidgets = new ArrayList<>(widgets);
         renderWidgets.sort((a, b) -> Integer.compare(a.style().getLayer(), b.style().getLayer()));
@@ -290,7 +315,11 @@ public final class LiquidGlassUniforms {
         }
 
 //#endif
+//#if MC >= 26.2
+        try (var map = widgetInfo.map(false, true)) {
+//#else
         try (var map = RenderSystem.getDevice().createCommandEncoder().mapBuffer(widgetInfo, false, true)) {
+//#endif
             Std140Builder b = Std140Builder.intoBuffer(map.data());
             b.putFloat((float) renderWidgets.size());
             b.align(16);
@@ -389,7 +418,9 @@ public final class LiquidGlassUniforms {
                         float sB = sc.getBottom() * scale;
 //#endif
                         b.putVec4(sL, fbH - sB, sR, fbH - sT);
-//#if MC >= 26
+//#if MC >= 26.2
+                    } else b.putVec4(0f, 0f, (float) mc.gameRenderer.mainRenderTarget().width, (float) mc.gameRenderer.mainRenderTarget().height);
+//#elseif MC >= 26
                     } else b.putVec4(0f, 0f, (float) mc.getMainRenderTarget().width, (float) mc.getMainRenderTarget().height);
 //#else
                     } else b.putVec4(0f, 0f, (float) mc.getFramebuffer().textureWidth, (float) mc.getFramebuffer().textureHeight);

--- a/src/main/java/restudio/reglass/client/ReGlassClient.java
+++ b/src/main/java/restudio/reglass/client/ReGlassClient.java
@@ -14,7 +14,9 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.components.Button;
 import com.mojang.blaze3d.platform.InputConstants;
 import net.minecraft.network.chat.Component;
+//#if MC < 26.2
 import net.minecraft.ChatFormatting;
+//#endif
 import net.minecraft.resources.Identifier;
 //#else
 import net.minecraft.client.MinecraftClient;
@@ -81,24 +83,38 @@ public class ReGlassClient implements ClientModInitializer {
                 registerKeyMappings(client);
             }
             handleGlobalToggleRedesignKey(client);
-//#if MC >= 26
+//#if MC >= 26.2
+            while (CONFIG_KEY.consumeClick()) {
+                if (client.gui.screen() == null) {
+//#elseif MC >= 26
             while (CONFIG_KEY.consumeClick()) {
                 if (client.screen == null) {
 //#else
             while (CONFIG_KEY.wasPressed()) {
                 if (client.currentScreen == null) {
 //#endif
+//#if MC >= 26.2
+                    client.setScreenAndShow(new ReGlassConfigScreen(null));
+//#else
                     client.setScreen(new ReGlassConfigScreen(null));
+//#endif
                 }
             }
-//#if MC >= 26
+//#if MC >= 26.2
+            while (PLAYGROUND_KEY.consumeClick()) {
+                if (client.gui.screen() == null) {
+//#elseif MC >= 26
             while (PLAYGROUND_KEY.consumeClick()) {
                 if (client.screen == null) {
 //#else
             while (PLAYGROUND_KEY.wasPressed()) {
                 if (client.currentScreen == null) {
 //#endif
+//#if MC >= 26.2
+                    client.setScreenAndShow(new PlaygroundScreen());
+//#else
                     client.setScreen(new PlaygroundScreen());
+//#endif
                 }
             }
         });
@@ -180,7 +196,10 @@ public class ReGlassClient implements ClientModInitializer {
         protected void init() {
             super.init();
 
-//#if MC >= 26
+//#if MC >= 26.2
+            WidgetStyle customStyle = WidgetStyle.create().tint(0xFFAA00, 0.4f).blurRadius(0).shadow(25f, 0.2f, 0f, 3f).smoothing(.05f).shadowColor(0x000000, 1.0f);
+            addRenderableWidget(new LiquidGlassWidget(width / 2 - 75, height / 2 - 25, 150, 50, customStyle).setMoveable(true));
+//#elseif MC >= 26
             WidgetStyle customStyle = WidgetStyle.create().tint(ChatFormatting.GOLD.getColor(), 0.4f).blurRadius(0).shadow(25f, 0.2f, 0f, 3f).smoothing(.05f).shadowColor(0x000000, 1.0f);
             addRenderableWidget(new LiquidGlassWidget(width / 2 - 75, height / 2 - 25, 150, 50, customStyle).setMoveable(true));
             addRenderableWidget(Button.builder(Component.literal("Toggle BG Blur"), b -> blur = !blur).bounds(10, 10, 120, 20).build());

--- a/src/main/java/restudio/reglass/client/ReGlassClient.java
+++ b/src/main/java/restudio/reglass/client/ReGlassClient.java
@@ -94,7 +94,7 @@ public class ReGlassClient implements ClientModInitializer {
                 if (client.currentScreen == null) {
 //#endif
 //#if MC >= 26.2
-                    client.setScreenAndShow(new ReGlassConfigScreen(null));
+                    client.gui.setScreen(new ReGlassConfigScreen(null));
 //#else
                     client.setScreen(new ReGlassConfigScreen(null));
 //#endif
@@ -111,7 +111,7 @@ public class ReGlassClient implements ClientModInitializer {
                 if (client.currentScreen == null) {
 //#endif
 //#if MC >= 26.2
-                    client.setScreenAndShow(new PlaygroundScreen());
+                    client.gui.setScreen(new PlaygroundScreen());
 //#else
                     client.setScreen(new PlaygroundScreen());
 //#endif

--- a/src/main/java/restudio/reglass/client/screen/config/ReGlassConfigScreen.java
+++ b/src/main/java/restudio/reglass/client/screen/config/ReGlassConfigScreen.java
@@ -73,11 +73,16 @@ public class ReGlassConfigScreen extends Screen {
 //#endif
             cfg.features.enableRedesign = !cfg.features.enableRedesign;
             button.setMessage(getEnableRedesignText());
-//#if MC >= 26
+//#if MC >= 26.2
             this.minecraft.gui.setScreen(new ReGlassConfigScreen(this.parent));
-        }).bounds(widgetX, y, widgetWidth, widgetHeight).build();
+//#elseif MC >= 26
+            this.minecraft.setScreen(new ReGlassConfigScreen(this.parent));
 //#else
             this.client.setScreen(new ReGlassConfigScreen(this.parent));
+//#endif
+//#if MC >= 26
+        }).bounds(widgetX, y, widgetWidth, widgetHeight).build();
+//#else
         }).dimensions(widgetX, y, widgetWidth, widgetHeight).build();
 //#endif
         addPositionedWidget(enableRedesignButton, y);
@@ -326,9 +331,12 @@ public class ReGlassConfigScreen extends Screen {
         addDrawableChild(ButtonWidget.builder(Text.translatable("controls.reset"), b -> {
 //#endif
             ReGlassSettingsIO.apply(new ReGlassSettingsIO.Data());
-//#if MC >= 26
+//#if MC >= 26.2
             if (this.minecraft != null) {
                 this.minecraft.gui.setScreen(new ReGlassConfigScreen(this.parent));
+//#elseif MC >= 26
+            if (this.minecraft != null) {
+                this.minecraft.setScreen(new ReGlassConfigScreen(this.parent));
 //#else
             if (this.client != null) {
                 this.client.setScreen(new ReGlassConfigScreen(this.parent));
@@ -483,9 +491,12 @@ public class ReGlassConfigScreen extends Screen {
     public void close() {
 //#endif
         ReGlassSettingsIO.saveFromMemory();
-//#if MC >= 26
+//#if MC >= 26.2
         if (this.minecraft != null) {
             this.minecraft.gui.setScreen(this.parent);
+//#elseif MC >= 26
+        if (this.minecraft != null) {
+            this.minecraft.setScreen(this.parent);
 //#else
         if (this.client != null) {
             this.client.setScreen(this.parent);

--- a/src/main/java/restudio/reglass/client/screen/config/ReGlassConfigScreen.java
+++ b/src/main/java/restudio/reglass/client/screen/config/ReGlassConfigScreen.java
@@ -74,7 +74,7 @@ public class ReGlassConfigScreen extends Screen {
             cfg.features.enableRedesign = !cfg.features.enableRedesign;
             button.setMessage(getEnableRedesignText());
 //#if MC >= 26
-            this.minecraft.setScreenAndShow(new ReGlassConfigScreen(this.parent));
+            this.minecraft.gui.setScreen(new ReGlassConfigScreen(this.parent));
         }).bounds(widgetX, y, widgetWidth, widgetHeight).build();
 //#else
             this.client.setScreen(new ReGlassConfigScreen(this.parent));

--- a/src/main/java/restudio/reglass/client/screen/config/ReGlassConfigScreen.java
+++ b/src/main/java/restudio/reglass/client/screen/config/ReGlassConfigScreen.java
@@ -74,7 +74,7 @@ public class ReGlassConfigScreen extends Screen {
             cfg.features.enableRedesign = !cfg.features.enableRedesign;
             button.setMessage(getEnableRedesignText());
 //#if MC >= 26
-            this.minecraft.setScreen(new ReGlassConfigScreen(this.parent));
+            this.minecraft.setScreenAndShow(new ReGlassConfigScreen(this.parent));
         }).bounds(widgetX, y, widgetWidth, widgetHeight).build();
 //#else
             this.client.setScreen(new ReGlassConfigScreen(this.parent));
@@ -328,7 +328,7 @@ public class ReGlassConfigScreen extends Screen {
             ReGlassSettingsIO.apply(new ReGlassSettingsIO.Data());
 //#if MC >= 26
             if (this.minecraft != null) {
-                this.minecraft.setScreen(new ReGlassConfigScreen(this.parent));
+                this.minecraft.setScreenAndShow(new ReGlassConfigScreen(this.parent));
 //#else
             if (this.client != null) {
                 this.client.setScreen(new ReGlassConfigScreen(this.parent));
@@ -378,7 +378,7 @@ public class ReGlassConfigScreen extends Screen {
 //#endif
 
 //#if MC >= 26
-        previewRounded = addRenderableWidget(new LiquidGlassWidget(previewX, previewY + 20, 140, 60, s2).setCornerRadiusPx(16f));
+        previewRounded = addRenderableWidget(new LiquidGlassWidget(previewX + 20, previewY + 120, 140, 60, s2).setCornerRadiusPx(16f));
 //#else
         previewRounded = addDrawableChild(new LiquidGlassWidget(previewX + 110, previewY + 20, 140, 60, s2).setCornerRadiusPx(16f));
 //#endif
@@ -485,7 +485,7 @@ public class ReGlassConfigScreen extends Screen {
         ReGlassSettingsIO.saveFromMemory();
 //#if MC >= 26
         if (this.minecraft != null) {
-            this.minecraft.setScreen(this.parent);
+            this.minecraft.setScreenAndShow(this.parent);
 //#else
         if (this.client != null) {
             this.client.setScreen(this.parent);

--- a/src/main/java/restudio/reglass/client/screen/config/ReGlassConfigScreen.java
+++ b/src/main/java/restudio/reglass/client/screen/config/ReGlassConfigScreen.java
@@ -328,7 +328,7 @@ public class ReGlassConfigScreen extends Screen {
             ReGlassSettingsIO.apply(new ReGlassSettingsIO.Data());
 //#if MC >= 26
             if (this.minecraft != null) {
-                this.minecraft.setScreenAndShow(new ReGlassConfigScreen(this.parent));
+                this.minecraft.gui.setScreen(new ReGlassConfigScreen(this.parent));
 //#else
             if (this.client != null) {
                 this.client.setScreen(new ReGlassConfigScreen(this.parent));
@@ -485,7 +485,7 @@ public class ReGlassConfigScreen extends Screen {
         ReGlassSettingsIO.saveFromMemory();
 //#if MC >= 26
         if (this.minecraft != null) {
-            this.minecraft.setScreenAndShow(this.parent);
+            this.minecraft.gui.setScreen(this.parent);
 //#else
         if (this.client != null) {
             this.client.setScreen(this.parent);

--- a/src/main/java/restudio/reglass/mixin/client/InGameHudMixin.java
+++ b/src/main/java/restudio/reglass/mixin/client/InGameHudMixin.java
@@ -3,7 +3,11 @@ package restudio.reglass.mixin.client;
 //#if MC >= 26
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.DeltaTracker;
+//#if MC >= 26.2
+import net.minecraft.client.gui.Hud;
+//#else
 import net.minecraft.client.gui.Gui;
+//#endif
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.world.entity.HumanoidArm;
 import net.minecraft.world.entity.player.Player;
@@ -31,7 +35,9 @@ import restudio.reglass.client.api.ReGlassApi;
 import restudio.reglass.client.api.ReGlassConfig;
 import restudio.reglass.client.api.WidgetStyle;
 
-//#if MC >= 26
+//#if MC >= 26.2
+@Mixin(Hud.class)
+//#elseif MC >= 26
 @Mixin(Gui.class)
 //#else
 @Mixin(InGameHud.class)
@@ -101,7 +107,9 @@ public abstract class InGameHudMixin {
             return;
         }
 
-//#if MC >= 26
+//#if MC >= 26.2
+        if (this.minecraft.gui.hud.isHidden()) {
+//#elseif MC >= 26
         if (this.minecraft.options.hideGui) {
 //#else
         if (this.client.options.hudHidden) {

--- a/src/main/java/restudio/reglass/mixin/logical/GameRendererMixin.java
+++ b/src/main/java/restudio/reglass/mixin/logical/GameRendererMixin.java
@@ -8,10 +8,17 @@ import com.mojang.blaze3d.pipeline.RenderPipeline;
 import com.mojang.blaze3d.systems.RenderPass;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.textures.FilterMode;
+//#if MC >= 26.2
+import com.mojang.blaze3d.PrimitiveTopology;
+//#endif
 import com.mojang.blaze3d.vertex.VertexFormat;
 import java.util.List;
 import java.util.OptionalDouble;
+//#if MC >= 26.2
+import java.util.Optional;
+//#else
 import java.util.OptionalInt;
+//#endif
 //#if MC >= 26
 import net.minecraft.client.Minecraft;
 //#else
@@ -84,7 +91,9 @@ public abstract class GameRendererMixin {
             List<Integer> radii = uniforms.getUsedBlurRadiiOrdered();
             LiquidGlassPrecomputeRuntime.get().setRequestedRadii(radii);
             LiquidGlassPrecomputeRuntime.get().run();
-//#if MC >= 26
+//#if MC >= 26.2
+            RenderTarget mainFb = this.minecraft.gameRenderer.mainRenderTarget();
+//#elseif MC >= 26
             RenderTarget mainFb = this.minecraft.getMainRenderTarget();
 //#else
             Framebuffer mainFb = this.client.getFramebuffer();
@@ -96,7 +105,11 @@ public abstract class GameRendererMixin {
 //#else
                     mainFb.getColorAttachmentView(),
 //#endif
+//#if MC >= 26.2
+                    Optional.empty(),
+//#else
                     OptionalInt.empty(),
+//#endif
 //#if MC >= 26
                     mainFb.useDepth ? mainFb.getDepthTextureView() : null,
 //#else
@@ -107,7 +120,9 @@ public abstract class GameRendererMixin {
                 RenderPipeline pipeline = LiquidGlassPipelines.getGuiPipeline();
                 pass.setPipeline(pipeline);
 
+//#if MC < 26.2
                 RenderSystem.bindDefaultUniforms(pass);
+//#endif
                 pass.setUniform("SamplerInfo", uniforms.getSamplerInfoBuffer());
                 pass.setUniform("CustomUniforms", uniforms.getCustomUniformsBuffer());
                 pass.setUniform("WidgetInfo", uniforms.getWidgetInfoBuffer());
@@ -120,14 +135,21 @@ public abstract class GameRendererMixin {
 
                 GuiRenderer guiRenderer = ((GameRendererAccessor) this).getGuiRenderer();
                 GpuBuffer quadVB = ((QuadVertexBufferProvider) guiRenderer).getQuadVertexBuffer();
-//#if MC >= 26
+//#if MC >= 26.2
+                RenderSystem.AutoStorageIndexBuffer quadIBInfo = RenderSystem.getSequentialBuffer(PrimitiveTopology.QUADS);
+                com.mojang.blaze3d.buffers.GpuBuffer quadIB = quadIBInfo.getBuffer(6);
+//#elseif MC >= 26
                 RenderSystem.AutoStorageIndexBuffer quadIBInfo = RenderSystem.getSequentialBuffer(VertexFormat.Mode.QUADS);
                 com.mojang.blaze3d.buffers.GpuBuffer quadIB = quadIBInfo.getBuffer(6);
 //#else
                 RenderSystem.ShapeIndexBuffer quadIBInfo = RenderSystem.getSequentialBuffer(VertexFormat.DrawMode.QUADS);
                 com.mojang.blaze3d.buffers.GpuBuffer quadIB = quadIBInfo.getIndexBuffer(6);
 //#endif
+//#if MC >= 26.2
+                pass.setVertexBuffer(0, quadVB.slice());
+//#else
                 pass.setVertexBuffer(0, quadVB);
+//#endif
 //#if MC >= 26
                 pass.setIndexBuffer(quadIB, quadIBInfo.type());
 //#else
@@ -164,7 +186,11 @@ public abstract class GameRendererMixin {
 //#endif
                     }
                 }
+//#if MC >= 26.2
+                pass.drawIndexed(6, 1, 0, 0, 0);
+//#else
                 pass.drawIndexed(0, 0, 6, 1);
+//#endif
             }
         }
     }

--- a/src/main/java/restudio/reglass/mixin/widgets/GuiRendererMixin.java
+++ b/src/main/java/restudio/reglass/mixin/widgets/GuiRendererMixin.java
@@ -6,7 +6,9 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.util.List;
 import net.minecraft.client.gui.render.GuiRenderer;
-//#if MC >= 26
+//#if MC >= 26.2
+import net.minecraft.client.renderer.state.gui.GuiRenderState;
+//#elseif MC >= 26
 import net.minecraft.client.renderer.state.gui.GuiRenderState;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.SubmitNodeCollector;
@@ -29,7 +31,9 @@ public class GuiRendererMixin implements QuadVertexBufferProvider {
     private GpuBuffer reglass$quadVertexBuffer;
 
     @Inject(method = "<init>", at = @At("TAIL"))
-//#if MC >= 26
+//#if MC >= 26.2
+    private void reglass$onInit(GuiRenderState state, net.minecraft.client.renderer.feature.FeatureRenderDispatcher dispatcher, List specialElementRenderers, CallbackInfo ci) {
+//#elseif MC >= 26
     private void reglass$onInit(GuiRenderState state, MultiBufferSource.BufferSource vertexConsumers, SubmitNodeCollector queue, net.minecraft.client.renderer.feature.FeatureRenderDispatcher dispatcher, List specialElementRenderers, CallbackInfo ci) {
 //#else
     private void reglass$onInit(GuiRenderState state, VertexConsumerProvider.Immediate vertexConsumers, OrderedRenderCommandQueue queue, net.minecraft.client.render.command.RenderDispatcher dispatcher, List specialElementRenderers, CallbackInfo ci) {

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'dev.kikugie.stonecutter'
 }
 
-stonecutter.active '26.1'
+stonecutter.active '26.2'
 
 tasks.register('buildAll') {
 	group = 'build'

--- a/versions/26.2/gradle.properties
+++ b/versions/26.2/gradle.properties
@@ -1,0 +1,16 @@
+# Fabric Properties
+# Check these on https://fabricmc.net/develop
+minecraft_version=26.2
+loader_version=0.19.3
+loom_version=1.17.12
+java_version=25
+
+# Dependencies
+fabric_version=0.153.0+26.2
+modmenu_version=20.0.0-beta.4
+
+# fabric.mod.json dependency ranges
+loader_dependency=>=0.19.3
+minecraft_dependency=>=26.2 <26.3
+java_dependency=>=25
+fabric_api_dependency=*


### PR DESCRIPTION
Adds support for 26.2 and the new Vulkan API added to this version. Changes:

- Migrated broken Blaze3D/client APIs (render target, GpuBuffer.map, GpuFormat, PrimitiveTopology, drawIndexed, GuiRenderer ctor, etc.)                                                                                                           
  - Vulkan pipeline fixes (bind-group layouts, dropped unused Projection uniform, color target state)                                                                                                                                               
- Other small changes to do with 26.2

I recently implemented a modified version of ReGlass into a project I'm working on, and since I had to create it for 26.2 I figured I should share the changes for the original repo. Love the project! 